### PR TITLE
Feature/security group assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ During deploy:
 * Launch the main.template.yaml template, which will launch all nested additional templates.
 
 After deploy: 
-* Assign the new created security group to VPC Endpoint created by AWS Transfer for SFTP service
 * Test you sftp connection using demo user. You can see password in the secret created in AWS Secrets Manager with the format SFTP/usecret.
 
 ## Contributing

--- a/transfer.template.yaml
+++ b/transfer.template.yaml
@@ -55,6 +55,8 @@ Resources:
         AddressAllocationIds:
           - !GetAtt EIPTran01.AllocationId
           - !GetAtt EIPTran02.AllocationId
+        SecurityGroupIds:
+          - !Ref TrSecurityGroup
         SubnetIds:
           - !Ref DMZSubnetA
           - !Ref DMZSubnetB


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Transfer Family Server supports assigning a Security Group to the Transfer Server: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-transfer-server-endpointdetails.html#cfn-transfer-server-endpointdetails-securitygroupids. This PR adds the security group using CloudFormation, reducing manual efforts to add it in after deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
